### PR TITLE
Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 *.jl.*.cov
 *.jl.mem
 
-doc/Manifest.toml
-doc/build/
-doc/site/
+docs/build/
 
 *.ipynb_checkpoints
 **/*.ipynb_checkpoints

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Roger-luo"]
 version = "0.2.2"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
+DocStringExtensions = "0.9"
 julia = "1.5"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Lattices = "c21dee59-005f-55b6-acfd-94526b082a96"
 
 [compat]
 Documenter = "1"
+
+[sources]
+Lattices = {path = ".."}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.19"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,22 +1,19 @@
-using Documenter, Lattices
+using Documenter
+using Lattices
 
-makedocs(
+makedocs(;
      modules = [Lattices],
-     format  = :html,
+     format = Documenter.HTML(),
      sitename = "Lattices",
      pages = Any[
-         "Introduction"   => "index.md"
+         "Introduction" => "index.md",
      ],
-     # Use clean URLs, unless built as a "local" build
-     html_prettyurls = !("local" in ARGS),
-     # html_canonical = "https://juliadocs.github.io/Documenter.jl/latest/",
+     warnonly = [:cross_references],
 )
 
 deploydocs(
-     repo = "github.com:Roger-luo/Lattices.jl.git",
+     repo = "github.com/JuliaPhysics/Lattices.jl.git",
      target = "build",
-     julia = "1.0",
-     osname = "osx",
      deps = nothing,
      make = nothing
 )

--- a/src/Lattices.jl
+++ b/src/Lattices.jl
@@ -3,6 +3,7 @@ module Lattices
 import Base: size, ndims, length, show, nameof, ==, axes, strides, checkbounds
 using Base.Iterators
 using LinearAlgebra
+using DocStringExtensions
 
 export AbstractLattice, WeightedLattice, CoordinateLattice
 

--- a/src/boundaries.jl
+++ b/src/boundaries.jl
@@ -1,4 +1,15 @@
+"""
+$(TYPEDEF)
+
+Abstract supertype for all boundary conditions.
+"""
 abstract type AbstractBoundary end
+
+"""
+$(TYPEDEF)
+
+Periodic boundary condition.
+"""
 struct Periodic <: AbstractBoundary end
 struct Open <: AbstractBoundary end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,9 +4,9 @@
 Abstract type for general lattices.
 For a more concrete definition please refer the following material:
 
-- Lattice (group): https://en.wikipedia.org/wiki/Lattice_(group)
-- Lattice Model: https://en.wikipedia.org/wiki/Lattice_model_(physics)
-- Lattice Graph: https://en.wikipedia.org/wiki/Lattice_graph
+- Lattice (group): <https://en.wikipedia.org/wiki/Lattice_(group)>
+- Lattice Model: <https://en.wikipedia.org/wiki/Lattice_model_(physics)>
+- Lattice Graph: <https://en.wikipedia.org/wiki/Lattice_graph>
 """
 abstract type AbstractLattice end
 


### PR DESCRIPTION
- Use newer Documenter
- Add docstrings for some types

In the current live version of the docs site, there are some methods/types documented that don't seem to exist anymore. Can someone please help me navigate that? (For now circumvented with the `warnonly` argument in the call to `makedocs()`)